### PR TITLE
Integration tests run nightly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,8 @@
 name: Integration tests
 
 on:
-
+  schedule:
+    - cron:  '0 2 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Set the cron expression for the GitHub Action 'integration test' to run around 2am each night