### PR TITLE
Test repository selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,13 +3,29 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "agent-integration-tests"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "flate2",
  "futures",
+ "http",
  "integration-test-commons",
  "k8s-openapi",
+ "nix",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tar",
  "tokio",
+ "uuid",
+ "warp",
 ]
 
 [[package]]
@@ -59,7 +75,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.3",
  "instant",
  "rand 0.8.4",
 ]
@@ -75,6 +91,31 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
+dependencies = [
+ "memchr",
+ "safemem",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -145,6 +186,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "darling"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +257,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -308,6 +376,30 @@ name = "encoding_index_tests"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
+name = "filetime"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
+dependencies = [
+ "cfg-if",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -441,6 +533,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,7 +561,26 @@ checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -456,6 +588,31 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "headers"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "mime",
+ "sha-1",
+ "time",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -510,6 +667,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -555,6 +713,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +740,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
 dependencies = [
  "unindent",
+]
+
+[[package]]
+name = "input_buffer"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -789,6 +967,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +1024,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "multipart"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050aeedc89243f5347c3e237e3e13dc76fbe4ae3742a57b94dc14f69acf76d4"
+dependencies = [
+ "buf_redux",
+ "httparse",
+ "log",
+ "mime",
+ "mime_guess",
+ "quick-error",
+ "rand 0.7.3",
+ "safemem",
+ "tempfile",
+ "twoway",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +1057,19 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -930,6 +1174,12 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -1091,6 +1341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,14 +1370,37 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc",
+ "rand_hc 0.3.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1151,11 +1430,29 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.3",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1191,7 +1488,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.3",
  "redox_syscall",
 ]
 
@@ -1243,6 +1540,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,6 +1578,12 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "security-framework"
@@ -1359,6 +1668,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,6 +1689,32 @@ dependencies = [
  "linked-hash-map",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a0c8611594e2ab4ebbf06ec7cbbf0a99450b8570e96cbf5188b5d5f6ef18d81"
+dependencies = [
+ "block-buffer",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+dependencies = [
+ "block-buffer",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1445,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator"
 version = "0.1.0-nightly"
-source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#2706ec7102d2a2627f74bd60349a85f02698fc36"
+source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#1f272d2d99c63ba28aa9cf8d2da87120584060d0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -1487,6 +1834,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d779dc6aeff029314570f666ec83f19df7280bb36ef338442cfa8c604021b80"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -1539,18 +1897,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
-name = "tokio"
-version = "1.8.1"
+name = "tinyvec"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tokio"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2602b8af3767c285202012822834005f596c811042315fa7e9f5b12b2a43207"
 dependencies = [
  "autocfg",
+ "bytes",
  "libc",
+ "memchr",
  "mio",
  "num_cpus",
  "once_cell",
@@ -1589,6 +1964,30 @@ checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a5f475f1b9d077ea1017ecbc60890fda8e54942d680ca0b1d2b47cfa2d861b"
+dependencies = [
+ "futures-util",
+ "log",
+ "pin-project 1.0.7",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -1753,6 +2152,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "tungstenite"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "input_buffer",
+ "log",
+ "rand 0.8.4",
+ "sha-1",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "twoway"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "typenum"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,12 +2225,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -1778,6 +2256,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "want"
@@ -1788,6 +2272,41 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "warp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332d47745e9a0c38636dbd454729b147d16bd1ed08ae67b3ab281c4506771054"
+dependencies = [
+ "bytes",
+ "futures",
+ "headers",
+ "http",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
+ "multipart",
+ "percent-encoding",
+ "pin-project 1.0.7",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -1816,6 +2335,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,17 @@ name = "agent-integration-tests"
 version = "0.1.0"
 
 [dependencies]
+anyhow = "1.0"
+flate2 = "1.0"
 futures = "0.3"
+http = "0.2"
 integration-test-commons = { git = "https://github.com/stackabletech/integration-test-commons.git", tag = "0.3.0" }
 k8s-openapi = { version = "0.12", default-features = false, features = ["v1_21"] }
+nix = "0.22"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sha2 = "0.9"
+tar = "0.4"
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
+uuid = { version = "0.8", features = ["v4"] }
+warp = "0.3"

--- a/tests/job.rs
+++ b/tests/job.rs
@@ -27,6 +27,8 @@ impl<'a> ExitService<'a> {
                         - name: EXIT_CODE
                           value: {exit_code}
                   restartPolicy: Never
+                  nodeSelector:
+                    kubernetes.io/arch: stackable-linux
                   tolerations:
                     - key: kubernetes.io/arch
                       operator: Equal

--- a/tests/job.rs
+++ b/tests/job.rs
@@ -11,7 +11,7 @@ impl<'a> ExitService<'a> {
 
         let pod = TemporaryResource::new(
             &client,
-            &with_unique_name(&format!(
+            &with_unique_name(&formatdoc!(
                 "
                 apiVersion: v1
                 kind: Pod

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -21,7 +21,8 @@ impl<'a> EchoService<'a> {
 
         let pod = TemporaryResource::new(
             &client,
-            &with_unique_name(&formatdoc! {r#"
+            &with_unique_name(&formatdoc!(
+                r#"
                 apiVersion: v1
                 kind: Pod
                 metadata:
@@ -43,7 +44,7 @@ impl<'a> EchoService<'a> {
                       value: stackable-linux
                 "#,
                 log_output = log_output.join(NEWLINE)
-            }),
+            )),
         );
 
         client.verify_pod_condition(&pod, "Ready");

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -35,6 +35,8 @@ impl<'a> EchoService<'a> {
                       env:
                         - name: LOG_OUTPUT
                           value: "{log_output}"
+                  nodeSelector:
+                    kubernetes.io/arch: stackable-linux
                   tolerations:
                     - key: kubernetes.io/arch
                       operator: Equal

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -1,0 +1,131 @@
+mod util;
+
+use std::fmt::Debug;
+
+use anyhow::{anyhow, Result};
+use integration_test_commons::test::prelude::*;
+use uuid::Uuid;
+
+use crate::util::{
+    repository::{StackableRepository, StackableRepositoryInstance},
+    services::noop_service,
+};
+
+#[tokio::test]
+async fn invalid_or_unreachable_repositories_should_be_ignored() -> Result<()> {
+    let client = KubeClient::new().await?;
+
+    let mut result = Ok(());
+
+    // Set up repositories and pod
+
+    // The agent processes the repositories by their name in
+    // alphabetical order.
+
+    let repository0_result = client
+        .create::<Repository>(
+            "
+                apiVersion: stable.stackable.de/v1
+                kind: Repository
+                metadata:
+                    name: 0-no-repository-url
+                    namespace: default
+                spec:
+                    repo_type: StackableRepo
+                    properties: {}
+            ",
+        )
+        .await;
+    combine(&mut result, &repository0_result);
+
+    let repository1_result = client
+        .create::<Repository>(
+            "
+                apiVersion: stable.stackable.de/v1
+                kind: Repository
+                metadata:
+                    name: 1-unreachable
+                    namespace: default
+                spec:
+                    repo_type: StackableRepo
+                    properties:
+                        url: https://unreachable
+            ",
+        )
+        .await;
+    combine(&mut result, &repository1_result);
+
+    let empty_repository = StackableRepository {
+        name: String::from("2-empty-repository"),
+        packages: Vec::new(),
+    };
+    let repository2_result = StackableRepositoryInstance::new(&empty_repository, &client).await;
+    combine(&mut result, &repository2_result);
+
+    let mut service = noop_service();
+    // Add a UUID to the service name to circumvent the package cache
+    service.name.push_str(&format!("-{}", Uuid::new_v4()));
+
+    let repository_with_service = StackableRepository {
+        name: String::from("3-repository-with-service"),
+        packages: vec![service.clone()],
+    };
+    let repository3_result =
+        StackableRepositoryInstance::new(&repository_with_service, &client).await;
+    combine(&mut result, &repository3_result);
+
+    let pod_result = client
+        .create::<Pod>(&service.pod_spec("agent-service-integration-test-repository"))
+        .await;
+    combine(&mut result, &pod_result);
+
+    // Verify that the pod was downloaded, started, and is ready
+
+    if let Ok(pod) = &pod_result {
+        let pod_ready = client.verify_pod_condition(&pod, "Ready").await;
+        combine(&mut result, &pod_ready);
+    }
+
+    // Tear down pod and repositories
+
+    if let Ok(pod) = pod_result {
+        let deletion_result = client.delete(pod).await;
+        combine(&mut result, &deletion_result);
+    }
+    if let Ok(repository3) = repository3_result {
+        let close_result = repository3.close(&client).await;
+        combine(&mut result, &close_result);
+    }
+    if let Ok(repository2) = repository2_result {
+        let close_result = repository2.close(&client).await;
+        combine(&mut result, &close_result);
+    }
+    if let Ok(repository1) = repository1_result {
+        let close_result = client.delete(repository1).await;
+        combine(&mut result, &close_result);
+    }
+    if let Ok(repository0) = repository0_result {
+        let close_result = client.delete(repository0).await;
+        combine(&mut result, &close_result);
+    }
+
+    // Return test result
+
+    result
+}
+
+/// Applies the AND operation to the given results
+///
+/// If `result` contains already an error then `other_result` is
+/// ignored else if `other_result` contains an error then it is applied
+/// on `result`.
+fn combine<T, E>(result: &mut Result<()>, other_result: &Result<T, E>)
+where
+    E: Debug,
+{
+    if result.is_ok() {
+        if let Err(error) = other_result {
+            *result = Err(anyhow!("{:?}", error))
+        }
+    }
+}

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -23,35 +23,35 @@ async fn invalid_or_unreachable_repositories_should_be_ignored() -> Result<()> {
     // alphabetical order.
 
     let repository0_result = client
-        .create::<Repository>(
+        .create::<Repository>(indoc!(
             "
-                apiVersion: stable.stackable.de/v1
-                kind: Repository
-                metadata:
-                    name: 0-no-repository-url
-                    namespace: default
-                spec:
-                    repo_type: StackableRepo
-                    properties: {}
-            ",
-        )
+            apiVersion: stable.stackable.de/v1
+            kind: Repository
+            metadata:
+                name: 0-no-repository-url
+                namespace: default
+            spec:
+                repo_type: StackableRepo
+                properties: {}
+            "
+        ))
         .await;
     combine(&mut result, &repository0_result);
 
     let repository1_result = client
-        .create::<Repository>(
+        .create::<Repository>(indoc!(
             "
-                apiVersion: stable.stackable.de/v1
-                kind: Repository
-                metadata:
-                    name: 1-unreachable
-                    namespace: default
-                spec:
-                    repo_type: StackableRepo
-                    properties:
-                        url: https://unreachable
-            ",
-        )
+            apiVersion: stable.stackable.de/v1
+            kind: Repository
+            metadata:
+                name: 1-unreachable
+                namespace: default
+            spec:
+                repo_type: StackableRepo
+                properties:
+                    url: https://unreachable
+            "
+        ))
         .await;
     combine(&mut result, &repository1_result);
 

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -10,7 +10,8 @@ fn service_should_be_started_successfully() {
 
     let pod = TemporaryResource::new(
         &client,
-        &with_unique_name(indoc! {"
+        &with_unique_name(indoc!(
+            "
             apiVersion: v1
             kind: Pod
             metadata:
@@ -27,7 +28,8 @@ fn service_should_be_started_successfully() {
                 - key: kubernetes.io/arch
                   operator: Equal
                   value: stackable-linux
-        "}),
+            "
+        )),
     );
 
     client.verify_pod_condition(&pod, "Ready");
@@ -41,7 +43,8 @@ fn host_ip_and_node_ip_should_be_set() {
 
     let pod = TemporaryResource::new(
         &client,
-        &with_unique_name(indoc! {"
+        &with_unique_name(indoc!(
+            "
             apiVersion: v1
             kind: Pod
             metadata:
@@ -58,7 +61,8 @@ fn host_ip_and_node_ip_should_be_set() {
                 - key: kubernetes.io/arch
                   operator: Equal
                   value: stackable-linux
-        "}),
+            "
+        )),
     );
 
     let are_host_ip_and_node_ip_set = |pod: &Pod| {
@@ -89,7 +93,8 @@ fn restart_after_ungraceful_shutdown_should_succeed() {
 
     setup_repository(&client);
 
-    let pod_spec = with_unique_name(&formatdoc! {"
+    let pod_spec = with_unique_name(&formatdoc!(
+        "
         apiVersion: v1
         kind: Pod
         metadata:
@@ -107,7 +112,9 @@ fn restart_after_ungraceful_shutdown_should_succeed() {
               operator: Equal
               value: stackable-linux
           terminationGracePeriodSeconds: {termination_grace_period_seconds}
-    ", termination_grace_period_seconds = termination_grace_period.as_secs()});
+        ",
+        termination_grace_period_seconds = termination_grace_period.as_secs()
+    ));
 
     for _ in 1..=2 {
         let pod = TemporaryResource::new(&client, &pod_spec);
@@ -154,25 +161,25 @@ async fn starting_and_stopping_100_pods_simultaneously_should_succeed() {
         node_name = node_name
     );
 
-    let pod_spec = format!(
+    let pod_spec = formatdoc!(
         "
-            apiVersion: v1
-            kind: Pod
-            metadata:
-              name: agent-service-integration-test-race-condition
-            spec:
-              containers:
-                - name: noop-service
-                  image: noop-service:1.0.0
-                  command:
-                    - noop-service-1.0.0/start.sh
-              nodeSelector:
-                kubernetes.io/arch: stackable-linux
-              tolerations:
-                - key: kubernetes.io/arch
-                  operator: Equal
-                  value: stackable-linux
-              nodeName: {node_name}
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: agent-service-integration-test-race-condition
+        spec:
+          containers:
+            - name: noop-service
+              image: noop-service:1.0.0
+              command:
+                - noop-service-1.0.0/start.sh
+          nodeSelector:
+            kubernetes.io/arch: stackable-linux
+          tolerations:
+            - key: kubernetes.io/arch
+              operator: Equal
+              value: stackable-linux
+          nodeName: {node_name}
         ",
         node_name = node_name
     );

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -21,6 +21,8 @@ fn service_should_be_started_successfully() {
                   image: noop-service:1.0.0
                   command:
                     - noop-service-1.0.0/start.sh
+              nodeSelector:
+                kubernetes.io/arch: stackable-linux
               tolerations:
                 - key: kubernetes.io/arch
                   operator: Equal
@@ -50,6 +52,8 @@ fn host_ip_and_node_ip_should_be_set() {
                   image: noop-service:1.0.0
                   command:
                     - noop-service-1.0.0/start.sh
+              nodeSelector:
+                kubernetes.io/arch: stackable-linux
               tolerations:
                 - key: kubernetes.io/arch
                   operator: Equal
@@ -96,6 +100,8 @@ fn restart_after_ungraceful_shutdown_should_succeed() {
               image: nostop-service:1.0.1
               command:
                 - nostop-service-1.0.1/start.sh
+          nodeSelector:
+            kubernetes.io/arch: stackable-linux
           tolerations:
             - key: kubernetes.io/arch
               operator: Equal
@@ -160,6 +166,8 @@ async fn starting_and_stopping_100_pods_simultaneously_should_succeed() {
                   image: noop-service:1.0.0
                   command:
                     - noop-service-1.0.0/start.sh
+              nodeSelector:
+                kubernetes.io/arch: stackable-linux
               tolerations:
                 - key: kubernetes.io/arch
                   operator: Equal

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,0 +1,3 @@
+pub mod repository;
+pub mod services;
+pub mod test_package;

--- a/tests/util/repository.rs
+++ b/tests/util/repository.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use anyhow::Result;
 use http::Uri;
-use integration_test_commons::test::{prelude::KubeClient, repository::Repository};
+use integration_test_commons::test::prelude::*;
 use nix::ifaddrs;
 use nix::net::if_::InterfaceFlags;
 use nix::sys::socket::SockAddr;
@@ -196,7 +196,10 @@ fn default_ip_address() -> Result<IpAddr> {
             }
         })
         .ok_or_else(|| {
-            anyhow!("No network interface found which is up, bound to an IP address, and not the loopback interface")
+            anyhow!(
+                "No network interface found which is up, bound to an \
+                    IP address, and not the loopback interface"
+            )
         })
 }
 
@@ -213,7 +216,8 @@ async fn register(
         .build()
         .unwrap();
 
-    let spec = format! {"
+    let spec = formatdoc!(
+        "
         apiVersion: stable.stackable.de/v1
         kind: Repository
         metadata:
@@ -223,8 +227,10 @@ async fn register(
             repo_type: StackableRepo
             properties:
                 url: {}
-        ", repository_name, uri
-    };
+        ",
+        repository_name,
+        uri
+    );
 
     client.create::<Repository>(&spec).await
 }

--- a/tests/util/repository.rs
+++ b/tests/util/repository.rs
@@ -1,0 +1,230 @@
+use anyhow::anyhow;
+use anyhow::Result;
+use http::Uri;
+use integration_test_commons::test::{prelude::KubeClient, repository::Repository};
+use nix::ifaddrs;
+use nix::net::if_::InterfaceFlags;
+use nix::sys::socket::SockAddr;
+use serde::Serialize;
+use sha2::{Digest, Sha512};
+use std::net::IpAddr;
+use std::{collections::HashMap, net::SocketAddr};
+use tokio::sync::oneshot::{self, Sender};
+use warp::{path::FullPath, Filter};
+
+use super::test_package::TestPackage;
+
+/// A specific version of a package in a Stackable repository
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct PackageVersion {
+    version: String,
+    path: String,
+    hashes: HashMap<String, String>,
+}
+
+impl From<&TestPackage> for PackageVersion {
+    fn from(package: &TestPackage) -> Self {
+        let binary = package.binary();
+
+        let hash = format!("{:x}", Sha512::digest(&binary));
+
+        let mut hashes = HashMap::new();
+        hashes.insert(String::from("SHA512"), hash);
+
+        PackageVersion {
+            version: package.version.to_owned(),
+            path: package.repository_path(),
+            hashes,
+        }
+    }
+}
+
+/// Content of a metadata file in a Stackable repository
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct StackableRepositoryMetadata {
+    version: String,
+    packages: HashMap<String, Vec<PackageVersion>>,
+}
+
+impl From<&[TestPackage]> for StackableRepositoryMetadata {
+    fn from(test_packages: &[TestPackage]) -> Self {
+        let mut packages = HashMap::new();
+
+        for package in test_packages {
+            let mut package_versions: Vec<_> = packages.remove(&package.name).unwrap_or_default();
+            package_versions.push(package.into());
+            packages.insert(package.name.to_owned(), package_versions);
+        }
+
+        StackableRepositoryMetadata {
+            version: String::from("1"),
+            packages,
+        }
+    }
+}
+
+/// Named Stackable repository with test packages
+pub struct StackableRepository {
+    pub name: String,
+    pub packages: Vec<TestPackage>,
+}
+
+/// A running instance of a Stackable repository
+pub struct StackableRepositoryInstance {
+    name: String,
+    repository: Repository,
+    shutdown_sender: Sender<()>,
+}
+
+impl StackableRepositoryInstance {
+    /// Creates a new instance of a Stackable repository
+    ///
+    /// A web server is started providing the repository content and
+    /// the repository is created on the Kubernetes API server.
+    ///
+    /// `close` must be called to stop and clean up this instance.
+    pub async fn new(
+        stackable_repository: &StackableRepository,
+        client: &KubeClient,
+    ) -> Result<Self> {
+        match serve(&stackable_repository.packages) {
+            Ok((address, shutdown_sender)) => {
+                match register(client, &stackable_repository.name, &address).await {
+                    Ok(repository) => {
+                        let instance = StackableRepositoryInstance {
+                            name: stackable_repository.name.to_owned(),
+                            repository,
+                            shutdown_sender,
+                        };
+                        Ok(instance)
+                    }
+                    Err(error) => {
+                        let _ = shutdown_sender.send(());
+                        Err(error)
+                    }
+                }
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Closes the Stackable repository instance
+    ///
+    /// The repository is deleted on the Kubernetes API server and the
+    /// web server is shut down.
+    pub async fn close(self, client: &KubeClient) -> Result<()> {
+        let mut errors = Vec::new();
+
+        if let Err(error) = client.delete(self.repository).await {
+            errors.push(format!(
+                "Repository [{:?}] could not be deleted: {:?}",
+                self.name, error
+            ));
+        }
+
+        if let Err(()) = self.shutdown_sender.send(()) {
+            errors.push(format!(
+                "Repository server [{:?}] could not be shut down",
+                self.name
+            ));
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow!(errors.join("; ")))
+        }
+    }
+}
+
+/// Starts a web server providing a Stackable repository with the given
+/// test packages.
+///
+/// The web server is bound to the IP address of the default interface
+/// on an ephemeral port.
+fn serve(packages: &[TestPackage]) -> Result<(SocketAddr, Sender<()>)> {
+    let ip_address = default_ip_address()?;
+    let socket_address = SocketAddr::new(ip_address, 0);
+
+    let packages_cloned = packages.to_owned();
+    let metadata_route = warp::path("metadata.json").map(move || {
+        warp::reply::json(&StackableRepositoryMetadata::from(packages_cloned.as_ref()))
+    });
+
+    let packages_cloned = packages.to_owned();
+    let package_route = warp::path::full().and_then(move |path: FullPath| {
+        let packages = packages_cloned.to_owned();
+
+        async move {
+            packages
+                .iter()
+                .find(|package| format!("/{}", package.repository_path()) == path.as_str())
+                .map(|package| package.binary())
+                .ok_or_else(warp::reject::not_found)
+        }
+    });
+
+    let routes = metadata_route.or(package_route);
+
+    let (tx, rx) = oneshot::channel::<()>();
+
+    let (address, server) =
+        warp::serve(routes).try_bind_with_graceful_shutdown(socket_address, async {
+            rx.await.ok();
+        })?;
+
+    tokio::task::spawn(server);
+
+    Ok((address, tx))
+}
+
+/// Returns the IP address of a network interface which is up and which
+/// is not the loopback interface.
+///
+/// Usually the default IP address is returned.
+fn default_ip_address() -> Result<IpAddr> {
+    ifaddrs::getifaddrs()?
+        .filter(|ifaddr| {
+            ifaddr.flags.contains(InterfaceFlags::IFF_UP)
+                && !ifaddr.flags.contains(InterfaceFlags::IFF_LOOPBACK)
+        })
+        .find_map(|ifaddr| {
+            if let Some(SockAddr::Inet(inet_addr)) = ifaddr.address {
+                Some(inet_addr.to_std().ip())
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| {
+            anyhow!("No network interface found which is up, bound to an IP address, and not the loopback interface")
+        })
+}
+
+/// Registers a Stackable repository on the Kubernetes API server
+async fn register(
+    client: &KubeClient,
+    repository_name: &str,
+    address: &SocketAddr,
+) -> Result<Repository> {
+    let uri = Uri::builder()
+        .scheme("http")
+        .authority(address.to_string().as_str())
+        .path_and_query("/")
+        .build()
+        .unwrap();
+
+    let spec = format! {"
+        apiVersion: stable.stackable.de/v1
+        kind: Repository
+        metadata:
+            name: {}
+            namespace: default
+        spec:
+            repo_type: StackableRepo
+            properties:
+                url: {}
+        ", repository_name, uri
+    };
+
+    client.create::<Repository>(&spec).await
+}

--- a/tests/util/services.rs
+++ b/tests/util/services.rs
@@ -1,0 +1,104 @@
+use integration_test_commons::test::prelude::*;
+
+use super::test_package::TestPackage;
+
+/// The echo-service prints the content of the environment variable
+/// `LOG_OUTPUT` to standard output and falls asleep.
+///
+/// A new line is appended so the content in `LOG_OUTPUT` should not end
+/// with a new line character.
+///
+/// The capacity of environment variables depends on the system but it
+/// is safe to store up to 120 kB in `LOG_OUTPUT`.
+///
+/// # Escape sequences
+///
+/// The following escape sequences are recognized:
+///
+/// - `\n`     new line
+/// - `\\`     backslash
+///
+/// # Example
+///
+/// ```
+/// $ LOG_OUTPUT='first line\nbackslash: \\\nheart: ♥' start.sh
+/// first line
+/// backslash: \
+/// heart: ♥
+/// ```
+#[allow(dead_code)]
+pub fn echo_service() -> TestPackage {
+    TestPackage {
+        name: String::from("echo-service"),
+        version: String::from("1.0.0"),
+        script: String::from(indoc! {r#"
+            #!/bin/sh
+
+            # Adding /run/current-system/sw/bin to PATH for NixOS support
+            PATH=$PATH:/run/current-system/sw/bin
+
+            printf '%b\n' "$LOG_OUTPUT"
+
+            sleep 1d
+        "#,
+        }),
+    }
+}
+
+/// The exit-service terminates immediately with the exit code contained
+/// in the environment variable `EXIT_CODE`. If the environment variable
+/// is not set then the exit code is 0.
+#[allow(dead_code)]
+pub fn exit_service() -> TestPackage {
+    TestPackage {
+        name: String::from("exit-service"),
+        version: String::from("1.0.0"),
+        script: String::from(indoc! {"
+            #!/bin/sh
+
+            exit ${EXIT_CODE:-0}
+        "}),
+    }
+}
+
+/// This service performs no operation and just sleeps.
+#[allow(dead_code)]
+pub fn noop_service() -> TestPackage {
+    TestPackage {
+        name: String::from("noop-service"),
+        version: String::from("1.0.0"),
+        script: String::from(indoc! {"
+            #!/bin/sh
+
+            # Adding /run/current-system/sw/bin to PATH for NixOS support
+            PATH=$PATH:/run/current-system/sw/bin
+
+            echo test-service started
+
+            sleep 1d
+        "}),
+    }
+}
+
+/// The nostop-service performs no action, it just sleeps. The
+/// difference to the noop service is, that this service will ignore
+/// SIGINT and SIGTERM, which effectively means that it will not stop
+/// when systemd asks it to stop.
+#[allow(dead_code)]
+pub fn nostop_service() -> TestPackage {
+    TestPackage {
+        name: String::from("nostop-service"),
+        version: String::from("1.0.1"),
+        script: String::from(indoc! {"
+            #!/bin/sh
+
+            # Adding /run/current-system/sw/bin to PATH for NixOS support
+            PATH=$PATH:/run/current-system/sw/bin
+
+            echo nostop-service started
+
+            trap '' INT TERM
+            sleep 1d
+        "}),
+    }
+}

--- a/tests/util/services.rs
+++ b/tests/util/services.rs
@@ -31,7 +31,8 @@ pub fn echo_service() -> TestPackage {
     TestPackage {
         name: String::from("echo-service"),
         version: String::from("1.0.0"),
-        script: String::from(indoc! {r#"
+        script: String::from(indoc!(
+            r#"
             #!/bin/sh
 
             # Adding /run/current-system/sw/bin to PATH for NixOS support
@@ -40,8 +41,8 @@ pub fn echo_service() -> TestPackage {
             printf '%b\n' "$LOG_OUTPUT"
 
             sleep 1d
-        "#,
-        }),
+            "#,
+        )),
     }
 }
 
@@ -53,11 +54,13 @@ pub fn exit_service() -> TestPackage {
     TestPackage {
         name: String::from("exit-service"),
         version: String::from("1.0.0"),
-        script: String::from(indoc! {"
+        script: String::from(indoc!(
+            "
             #!/bin/sh
 
             exit ${EXIT_CODE:-0}
-        "}),
+            "
+        )),
     }
 }
 
@@ -67,7 +70,8 @@ pub fn noop_service() -> TestPackage {
     TestPackage {
         name: String::from("noop-service"),
         version: String::from("1.0.0"),
-        script: String::from(indoc! {"
+        script: String::from(indoc!(
+            "
             #!/bin/sh
 
             # Adding /run/current-system/sw/bin to PATH for NixOS support
@@ -76,7 +80,8 @@ pub fn noop_service() -> TestPackage {
             echo test-service started
 
             sleep 1d
-        "}),
+            "
+        )),
     }
 }
 
@@ -89,7 +94,8 @@ pub fn nostop_service() -> TestPackage {
     TestPackage {
         name: String::from("nostop-service"),
         version: String::from("1.0.1"),
-        script: String::from(indoc! {"
+        script: String::from(indoc!(
+            "
             #!/bin/sh
 
             # Adding /run/current-system/sw/bin to PATH for NixOS support
@@ -99,6 +105,7 @@ pub fn nostop_service() -> TestPackage {
 
             trap '' INT TERM
             sleep 1d
-        "}),
+            "
+        )),
     }
 }

--- a/tests/util/test_package.rs
+++ b/tests/util/test_package.rs
@@ -16,7 +16,7 @@ impl TestPackage {
 
         let mut header = tar::Header::new_gnu();
         header.set_size(self.script.len() as u64);
-        header.set_mode(0x755);
+        header.set_mode(0o755);
         header.set_cksum();
 
         tar.append_data(&mut header, self.command(), self.script.as_bytes())

--- a/tests/util/test_package.rs
+++ b/tests/util/test_package.rs
@@ -1,0 +1,71 @@
+use flate2::{write::GzEncoder, Compression};
+
+/// Package with a shell script used for testing
+#[derive(Clone, Debug)]
+pub struct TestPackage {
+    pub name: String,
+    pub version: String,
+    pub script: String,
+}
+
+impl TestPackage {
+    /// Returns the packaged script as .tar.gz
+    pub fn binary(&self) -> Vec<u8> {
+        let enc = GzEncoder::new(Vec::new(), Compression::default());
+        let mut tar = tar::Builder::new(enc);
+
+        let mut header = tar::Header::new_gnu();
+        header.set_size(self.script.len() as u64);
+        header.set_mode(0x755);
+        header.set_cksum();
+
+        tar.append_data(&mut header, self.command(), self.script.as_bytes())
+            .unwrap();
+
+        tar.into_inner().unwrap().finish().unwrap()
+    }
+
+    /// Returns the filename of the packaged script
+    pub fn filename(&self) -> String {
+        format!("{}-{}.tar.gz", self.name, self.version)
+    }
+
+    /// Returns the repository path where the package should be provided
+    pub fn repository_path(&self) -> String {
+        format!("{}/{}", self.name, self.filename())
+    }
+
+    /// Returns the command which is used to start the script after
+    /// unpacking
+    pub fn command(&self) -> String {
+        format!("{}-{}/start.sh", self.name, self.version)
+    }
+
+    /// Creates a pod specification for this package
+    pub fn pod_spec(&self, pod_name: &str) -> String {
+        format!(
+            "
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: {pod_name}
+                spec:
+                  containers:
+                    - name: {package_name}
+                      image: {package_name}:{package_version}
+                      command:
+                        - {command}
+                  nodeSelector:
+                    kubernetes.io/arch: stackable-linux
+                  tolerations:
+                    - key: kubernetes.io/arch
+                      operator: Equal
+                      value: stackable-linux
+            ",
+            pod_name = pod_name,
+            package_name = self.name,
+            package_version = self.version,
+            command = self.command()
+        )
+    }
+}

--- a/tests/util/test_package.rs
+++ b/tests/util/test_package.rs
@@ -45,22 +45,22 @@ impl TestPackage {
     pub fn pod_spec(&self, pod_name: &str) -> String {
         format!(
             "
-                apiVersion: v1
-                kind: Pod
-                metadata:
-                  name: {pod_name}
-                spec:
-                  containers:
-                    - name: {package_name}
-                      image: {package_name}:{package_version}
-                      command:
-                        - {command}
-                  nodeSelector:
-                    kubernetes.io/arch: stackable-linux
-                  tolerations:
-                    - key: kubernetes.io/arch
-                      operator: Equal
-                      value: stackable-linux
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: {pod_name}
+            spec:
+              containers:
+                - name: {package_name}
+                  image: {package_name}:{package_version}
+                  command:
+                    - {command}
+              nodeSelector:
+                kubernetes.io/arch: stackable-linux
+              tolerations:
+                - key: kubernetes.io/arch
+                  operator: Equal
+                  value: stackable-linux
             ",
             pod_name = pod_name,
             package_name = self.name,


### PR DESCRIPTION
Tests stackabletech/agent#229

The agent-integration-tests now serve the repositories which are required for the test case. An asynchronous context is necessary which makes it impossible to use `TemporaryResource` because asynchronous Drop traits are not supported yet. Also the assertion framework cannot be used anymore because an assertion would panic if it is not met. This would skip the cleanup which would be done in the Drop trait.

The ad-hoc repositories increase the convenience on the one hand but on the other hand they decrease it. Therefore the other test cases are not converted yet to these ad-hoc repositories. If the code proves useful after a while then it can be moved to the integration-test-commons.