### PR TITLE
Fix GitHub workflow for cargo deny

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,11 +84,10 @@ jobs:
           - advisories
           - bans licenses sources
 
-    # Prevent sudden announcement of a new advisory from failing ci:
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
-
     steps:
       - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check ${{ matrix.checks }}
+        # Prevent sudden announcement of a new advisory from failing ci:
+        continue-on-error: ${{ matrix.checks == 'advisories' }}


### PR DESCRIPTION
## Description

`cargo deny` now continues on errors when checking advisories.

## Review Checklist
- [x] Code contains useful comments
