### PR TITLE
Added files to run integration tests with Stackable CI infrastructure

### DIFF
--- a/.ci/integration-tests/aws-centos-8/cluster.yaml
+++ b/.ci/integration-tests/aws-centos-8/cluster.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: aws-centos-8
+metadata: 
+  name: agent-integration-tests
+  description: "Cluster for Agent Integration Tests (AWS EC2 / CentOS 8)"
+domain: stackable.test
+publicKeys: []
+spec:
+  region: eu-central-1
+  wireguard: false
+  versions:
+    stackable-agent: "*0.nightly.el8.x86_64"
+  nodes:
+    main:
+      numberOfNodes: 1
+    testdriver:
+      numberOfNodes: 1
+      agent: false

--- a/.ci/integration-tests/aws-centos-8/test.sh
+++ b/.ci/integration-tests/aws-centos-8/test.sh
@@ -1,0 +1,6 @@
+/stackable.sh testdriver-1 -i /.cluster/key 'sudo sh -c "echo \"13.32.25.75     static.rust-lang.org\" >> /etc/hosts"'
+/stackable.sh testdriver-1 -i /.cluster/key 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y'
+/stackable.sh testdriver-1 -i /.cluster/key 'cargo --version'
+/stackable.sh testdriver-1 -i /.cluster/key 'sudo yum install vim procps curl gcc make pkgconfig openssl-devel systemd-devel python3-pip container-selinux selinux-policy-base git -y'
+/stackable.sh testdriver-1 -i /.cluster/key "git clone https://github.com/stackabletech/agent-integration-tests.git"
+/stackable.sh testdriver-1 -i /.cluster/key 'cd agent-integration-tests/ && cargo test'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Integration tests
 
 on:
-  schedule:
-    - cron:  '0 2 * * *'
   workflow_dispatch:
 
 jobs:

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Agent integration tests
 
-image:https://github.com/stackabletech/agent-integration-tests/workflows/Rust/badge.svg[link="https://github.com/stackabletech/agent-integration-tests/actions"] image:https://github.com/stackabletech/agent-integration-tests/workflows/Security%20audit/badge.svg[link="https://github.com/stackabletech/agent-integration-tests/actions"] image:https://github.com/stackabletech/agent-integration-tests/workflows/Integration%20tests/badge.svg[link="https://github.com/stackabletech/agent-integration-tests/actions"]
+image:https://github.com/stackabletech/agent-integration-tests/workflows/Rust/badge.svg[link="https://github.com/stackabletech/agent-integration-tests/actions"] image:https://github.com/stackabletech/agent-integration-tests/workflows/Security%20audit/badge.svg[link="https://github.com/stackabletech/agent-integration-tests/actions"] image:https://ci.stackable.tech/job/Agent%20Integration%20Tests/badge/icon?subject=Integration%20Tests[link="https://ci.stackable.tech/job/Agent%20Integration%20Tests"]
 
 == Purpose
 The agent integration tests contain test cases for testing the


### PR DESCRIPTION
## Description
The integration tests are now run in the new CI (https://ci.stackable.tech). The files in the .ci/ folder contain the cluster definition and test script and execute the same tests as the GitHub Actions workflow test.yml did before. The latter is not deleted but only deactivated, because the transition is not fully completed.

## Review Checklist
- [x] Code contains useful comments
