### PR TITLE
read agent logs from cluster as build artifact

### DIFF
--- a/.ci/integration-tests/aws-centos-8/test.sh
+++ b/.ci/integration-tests/aws-centos-8/test.sh
@@ -4,3 +4,4 @@
 /stackable.sh testdriver-1 -i /.cluster/key 'sudo yum install vim procps curl gcc make pkgconfig openssl-devel systemd-devel python3-pip container-selinux selinux-policy-base git -y'
 /stackable.sh testdriver-1 -i /.cluster/key "git clone -b $GIT_BRANCH https://github.com/stackabletech/agent-integration-tests.git"
 /stackable.sh testdriver-1 -i /.cluster/key 'cd agent-integration-tests/ && cargo test'
+/stackable.sh main-1 -i /.cluster/key 'journalctl -u stackable-agent' > /target/stackable-agent.log


### PR DESCRIPTION
## Description
The logfile of the Stackable agent in the T2 testcluster will be downloaded and archived as a build job artifact.
A successful test run with the archived logs can be looked at here: https://ci.stackable.tech/view/02%20Component%20Tests%20(flex)/job/Agent%20Integration%20Tests%20(flex)/21/

## Review Checklist
- [x] Code contains useful comments
