### PR TITLE
exit code of actual test is returned by test script

### DIFF
--- a/.ci/integration-tests/aws-centos-8/test.sh
+++ b/.ci/integration-tests/aws-centos-8/test.sh
@@ -4,4 +4,6 @@
 /stackable.sh testdriver-1 -i /.cluster/key 'sudo yum install vim procps curl gcc make pkgconfig openssl-devel systemd-devel python3-pip container-selinux selinux-policy-base git -y'
 /stackable.sh testdriver-1 -i /.cluster/key "git clone -b $GIT_BRANCH https://github.com/stackabletech/agent-integration-tests.git"
 /stackable.sh testdriver-1 -i /.cluster/key 'cd agent-integration-tests/ && cargo test'
+exit_code=$?
 /stackable.sh main-1 -i /.cluster/key 'journalctl -u stackable-agent' > /target/stackable-agent.log
+exit $exit_code


### PR DESCRIPTION
## Description
Bug: After adding a line to the test script to retrieve a logfile from the cluster, a potential test failure was hidden from the user because the failed command was not the last one in the script.
Fix: The test result is stored in a variable which is used as the exit code in the last command of the script.

## Review Checklist
- [ ] Code contains useful comments
