### PR TITLE
Set correct content type to HTTP responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,8 +633,8 @@ dependencies = [
 
 [[package]]
 name = "integration-test-commons"
-version = "0.5.0"
-source = "git+https://github.com/stackabletech/integration-test-commons.git?tag=0.5.0#a2fbd7fa7f1152896730d89409e69ae3e804402f"
+version = "0.6.0"
+source = "git+https://github.com/stackabletech/integration-test-commons.git?tag=0.6.0#f2cf4ead8c6a3eb723ddcb9a5c804aeef9ffb5e9"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0"
 flate2 = "1.0"
 futures = "0.3"
 http = "0.2"
-integration-test-commons = { git = "https://github.com/stackabletech/integration-test-commons.git", tag = "0.5.0" }
+integration-test-commons = { git = "https://github.com/stackabletech/integration-test-commons.git", tag = "0.6.0" }
 k8s-openapi = { version = "0.13", default-features = false, features = ["v1_22"] }
 kube = { version = "0.60", features = ["derive"] }
 nix = "0.23"


### PR DESCRIPTION
## Description

The repositories responded with content type "application/octet-stream" but the Stackable Agent expects now "application/gzip" (see stackabletech/agent#326).

## Review Checklist
- [x] Code contains useful comments
