### PR TITLE
renamed template for IONOS

### DIFF
--- a/.ci/integration-tests/ionos-centos-7/cluster.yaml
+++ b/.ci/integration-tests/ionos-centos-7/cluster.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: t2.stackable.tech/v1
 kind: Infra
-template: demo-centos-7
+template: ionos-centos-7
 metadata: 
   name: agent-integration-tests
   description: "Cluster for Agent Integration Tests (IONOS / CentOS 7)"

--- a/.ci/integration-tests/ionos-debian-10/cluster.yaml
+++ b/.ci/integration-tests/ionos-debian-10/cluster.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: t2.stackable.tech/v1
 kind: Infra
-template: demo-debian-10
+template: ionos-debian-10
 metadata: 
   name: agent-integration-tests
   description: "Cluster for Agent Integration Tests (IONOS / Debian 10)"


### PR DESCRIPTION
## Description
The templates formerly known as "demo" are now named correctly with "ionos-..." Therefore, the cluster definition files for the integration tests had to be adjusted

## Review Checklist
- [x] Code contains useful comments
